### PR TITLE
feat: add support for decryption

### DIFF
--- a/pkcs11/pkcs11_test.go
+++ b/pkcs11/pkcs11_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/pem"
@@ -592,5 +593,79 @@ func TestCreateCertificate(t *testing.T) {
 	}
 	if !bytes.Equal(gotCert.Raw, cert.Raw) {
 		t.Errorf("Returned certificate did not match loaded certificate")
+	}
+}
+
+func TestDecryptOAEP(t *testing.T) {
+	msg := "Plain text to encrypt"
+	b := []byte(msg)
+	tests := []struct {
+		name string
+		bits int
+	}{
+		{"2048", 2048},
+		{"4096", 4096},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := newTestSlot(t)
+			o := keyOptions{RSABits: test.bits}
+			priv, err := s.generate(o)
+			if err != nil {
+				t.Fatalf("generate(%#v) failed: %v", o, err)
+			}
+			rsaPub := priv.(*rsaPrivateKey).pub
+			// SHA1 is the only hash function supported by softhsm
+			cipher, err := rsa.EncryptOAEP(sha1.New(), rand.Reader, rsaPub, b, nil)
+			if err != nil {
+				t.Fatalf("EncryptOAEP Error: %v", err)
+			}
+			opts := &rsa.OAEPOptions{Hash: crypto.SHA1}
+			rsaDecrypter := priv.(crypto.Decrypter)
+			decrypted, err := rsaDecrypter.Decrypt(nil, cipher, opts)
+			if err != nil {
+				t.Fatalf("Decrypt Error: %v", err)
+			}
+			if string(decrypted) != msg {
+				t.Errorf("Decrypt Error: expected %q, got %q", msg, string(decrypted))
+			}
+		})
+	}
+}
+
+func TestDecryptPKCS(t *testing.T) {
+	msg := "Plain text to encrypt"
+	b := []byte(msg)
+	tests := []struct {
+		name string
+		bits int
+	}{
+		{"2048", 2048},
+		{"4096", 4096},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := newTestSlot(t)
+			o := keyOptions{RSABits: test.bits}
+			priv, err := s.generate(o)
+			if err != nil {
+				t.Fatalf("generate(%#v) failed: %v", o, err)
+			}
+			rsaPub := priv.(*rsaPrivateKey).pub
+			cipher, err := rsa.EncryptPKCS1v15(rand.Reader, rsaPub, b)
+			if err != nil {
+				t.Fatalf("EncryptPKCS1v15 Error: %v", err)
+			}
+			rsaDecrypter := priv.(crypto.Decrypter)
+
+			// nil opts for decrypting using PKCS #1 v 1.5
+			decrypted, err := rsaDecrypter.Decrypt(nil, cipher, nil)
+			if err != nil {
+				t.Fatalf("Decrypt Error: %v", err)
+			}
+			if string(decrypted) != msg {
+				t.Errorf("Decrypt Error: expected %q, got %q", msg, string(decrypted))
+			}
+		})
 	}
 }


### PR DESCRIPTION
* added C wrapper for encrypt and decrypt functions

* typo in error message fix

* base encrypt and decrypt template from Sign function

* Added parameters to Encrypt and Decrypt API.

* Added WithHash API to allow overriding hash function.

* Encrypt RSA functionality added with empty unit test

* unit testing for encryptOAEP added

* encryptOAEP -> encryptRSA function renaming

* updated encryptRSA to get public key handle

* encryptRSA unit test fix

* sha1 renaming in encryptRSA

* Update module path

* Fix failure

* changed boolean flag to true to require softhsm

* go formatting changes from gofmt

* added draft decrypt functionality with unit testing

* Fix two bugs. 1. Wrong variable is used in for loop. 2. Need to query PKCS #11 for decrypt size.

* added benchmark test for encryptRSA

* deleted commented out code for Encrypt

* set requireSoftHSMv2 flag back to false

* added helper functions for converting between go bytes and C bytes

* gofmt formatting changes

* added helper function for creating mechanisms

* updated length declarations for ck_encrypt and ck_decrypt; updated TestDecryptRSA

* updated decrypt unit test to trim null characters from decrypted data

* made rsaPrivateKey.pubH a value instead of a pointer

* added helper function to build cParams and updated unit test for encryptRSA

---------

Co-authored-by: Carl Lundin <clundin@google.com>

ECP integration (#6)

* test commit

* removed test comment

* exposed encrypt and decrypt API

* Encrypt error message fix

* updated WithHash to use crypto.PrivateKey

* updated WithPublicKeyHandle to support public types

* updated comments, made sha256 default, and fixed formatting inconsistencies

* withpublickeyhandle call fix

empty commit (#7)

* empty commit

* updated libsofthsm2 path